### PR TITLE
Allow Tool compatibility fix

### DIFF
--- a/Source/Vampires/HarmonyPatches/HarmonyPatches.cs
+++ b/Source/Vampires/HarmonyPatches/HarmonyPatches.cs
@@ -182,7 +182,7 @@ namespace Vampire
                 new HarmonyMethod(typeof(HarmonyPatches), nameof(Accepts_VampBed)), null);
             harmony.Patch(AccessTools.Method(typeof(Building_Grave), "get_Graphic"),
                 new HarmonyMethod(typeof(HarmonyPatches), nameof(get_Graphic_VampBed)), null);
-            harmony.Patch(AccessTools.Method(typeof(Building_Casket), "GetFloatMenuOptions"), null,
+            harmony.Patch(AccessTools.Method(typeof(ThingWithComps), "GetFloatMenuOptions"), null,
                 new HarmonyMethod(typeof(HarmonyPatches), nameof(GetFloatMenuOptions_VampBed)));
             harmony.Patch(AccessTools.Method(typeof(WorkGiver_BuryCorpses), "FindBestGrave"), null,
                 new HarmonyMethod(typeof(HarmonyPatches), nameof(FindBestGrave_VampBed)));
@@ -1880,7 +1880,7 @@ namespace Vampire
             return true;
         }
         
-        public static void GetFloatMenuOptions_VampBed(Building_Casket __instance, Pawn selPawn, ref IEnumerable<FloatMenuOption> __result)
+        public static void GetFloatMenuOptions_VampBed(ThingWithComps __instance, Pawn selPawn, ref IEnumerable<FloatMenuOption> __result)
         {
             if (__instance.GetComps<CompVampBed>() is CompVampBed b)
             {


### PR DESCRIPTION
This change should restore full compatibility between Vampires and Allow Tool.

Allow Tool has a postfix on the method `ThingWithComps.GetFloatMenuOptions` which is not getting called when Vampires is also loaded. This happens because Vampires patches `Building_Casket.GetFloatMenuOptions`, which does not exist, but is still processed correctly by Harmony by patching that method on the base type. This somehow overwrites patches applied to the base method directly.  
I guess that would count as a Harmony bug, but we can easily work around it on our end.

For reference, [here is the patch added by Allow Tool](https://github.com/UnlimitedHugs/RimworldAllowTool/blob/master/Source/Patches/Thing_GetFloatMenuOptions_Patch.cs).